### PR TITLE
Fix issue where charge iframes had a bad url

### DIFF
--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -8,13 +8,19 @@ class App extends React.Component{
     super(props);
 
     this.state = {
-      checkoutId: ''
+      checkoutId: '',
+      chargeId: ''
     };
     this.updateCheckoutId = this.updateCheckoutId.bind(this);
+    this.updateChargeId = this.updateChargeId.bind(this);
   }
 
   updateCheckoutId(e){
     this.setState({checkoutId: e.target.value})
+  }
+
+  updateChargeId(e){
+    this.setState({chargeId: e.target.value})
   }
 
   render(){
@@ -29,6 +35,18 @@ class App extends React.Component{
             <CoinbaseCommerceButton checkoutId={this.state.checkoutId}>Ugly Button With Crypto</CoinbaseCommerceButton>
             <Button checkoutId={this.state.checkoutId}>Pretty Custom Button</Button>
             <DangerButton checkoutId={'wrongo'}>This Button is Bad</DangerButton>
+          </React.Fragment>
+        ) : null}
+
+        <span>Enter a charge ID: </span>
+        <input type='text' onChange={this.updateChargeId}/><br/>
+        {this.state.chargeId.length > 0 ? (
+          <React.Fragment>
+            <CoinbaseCommerceButton styled={true} chargeId={this.state.chargeId}/>
+            <CoinbaseCommerceButton styled={true} disabled>Disabled Button</CoinbaseCommerceButton>
+            <CoinbaseCommerceButton chargeId={this.state.chargeId}>Ugly Button With Crypto</CoinbaseCommerceButton>
+            <Button chargeId={this.state.chargeId}>Pretty Custom Button</Button>
+            <DangerButton chargeId={'wrongo'}>This Button is Bad</DangerButton>
           </React.Fragment>
         ) : null}
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-coinbase-commerce",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "react-coinbase-commerce",
   "version": "1.0.0",
   "description": "A react component to easily embed a Coinbase Commerce Checkout within your application",
-  "keywords": ["react", "cryptocurrency", "coinbase", "commerce", "bitcoin", "litecoin", "ethereum"],
+  "keywords": [
+    "react",
+    "cryptocurrency",
+    "coinbase",
+    "commerce",
+    "bitcoin",
+    "litecoin",
+    "ethereum"
+  ],
   "homepage": "https://github.com/coinbase/react-coinbase-commerce",
   "main": "dist/index.js",
   "scripts": {
@@ -30,7 +38,7 @@
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
     },
     "globals": {
-        "VERSION": "1"
+      "VERSION": "1"
     }
   },
   "author": "Tyson Battistella",

--- a/src/components/IFrame.js
+++ b/src/components/IFrame.js
@@ -102,7 +102,7 @@ export default class IFrame extends React.Component<Props, State> {
   render(){
     const {checkoutId, chargeId} = this.props;
 
-    const widgetType = checkoutId ? 'checkout' : chargeId ? 'charge' : null;
+    const widgetType = checkoutId ? 'checkout' : chargeId ? 'charges' : null;
     if(!widgetType){
       throw new Error('must supply either checkoutId or chargeId prop');
     }


### PR DESCRIPTION
This fixes an issue with charge embed urls. 

Currently, the charge url gets set to: 
`https://commerce.coinbase.com/embed/charge/XXXXX` 

when it should be plural: 
`https://commerce.coinbase.com/embed/charges/XXXXXX`

I also added an example for charges to the demo. If you remove the `s` and try it, it fails.