### PR TITLE
[fix] 👨‍🎤 handle oauth redirects in Safari

### DIFF
--- a/src/components/IFrame.js
+++ b/src/components/IFrame.js
@@ -53,7 +53,7 @@ export default class IFrame extends React.Component<Props, State> {
   componentDidMount(){
     // Add event listeners for the iframe
     window.addEventListener('message', this.handleMessage);
-    const hostName = `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}`;
+    const hostName = `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}/`;
     this.setState({ src: this.buildSrc(hostName) });
   }
 

--- a/src/components/__snapshots__/IFrame.spec.js.snap
+++ b/src/components/__snapshots__/IFrame.spec.js.snap
@@ -9,7 +9,7 @@ exports[`it renders and matches its snapshot 1`] = `
     frameBorder="no"
     onLoad={[Function]}
     scrolling="no"
-    src="https://commerce.coinbase.com/embed/checkout/aaaa?origin=http%3A%2F%2Flocalhost&version=1&buttonId=undefined&cacheDisabled=undefined"
+    src="https://commerce.coinbase.com/embed/checkout/aaaa?origin=http%3A%2F%2Flocalhost%2F&version=1&buttonId=undefined&cacheDisabled=undefined"
   />
 </div>
 `;


### PR DESCRIPTION
This PR fixes #62, which identifies OAuth redirect issues in Safari and Mobile Safari.

> TL;DR
 Ensure any redirect url contains a trailing slash 👨‍🎤 

Safari strips the hash fragment on redirects _unless_ the callback url has a trailing slash. Special thanks to [this old answer on stack overflow](https://stackoverflow.com/questions/18663410/safari-ignoring-removing-anchors-or-hashtags-when-clicking-hyperlinks/18698307#18698307) for identifying and documenting the issue 👏 